### PR TITLE
fix large loss during llama2 post-training

### DIFF
--- a/post_training.py
+++ b/post_training.py
@@ -44,8 +44,11 @@ def main(args):
     if ddp:
         gradient_accumulation_steps = gradient_accumulation_steps // world_size
 
-    if device == 'cuda':
-        model.half()
+    if 'Llama-2' in args.base_model:
+        model = model.float() # prevent nan/large loss during training llama2
+    else:
+        if device == 'cuda':
+            model.half()
 
     tokenizer.pad_token_id = 0
     tokenizer.padding_side = "left"


### PR DESCRIPTION
Fixes #81 

When loading pruned model (output of hf_prune.py) in post_training, cast model to fp32 if base_model is llama2